### PR TITLE
Add SVG support

### DIFF
--- a/lib/src/assets_builder.dart
+++ b/lib/src/assets_builder.dart
@@ -71,6 +71,7 @@ class AssetsBuilder implements Builder {
         ".jpg": [genFileSuffix],
         ".png": [genFileSuffix],
         ".webp": [genFileSuffix],
-        ".gif": [genFileSuffix]
+        ".gif": [genFileSuffix],
+        ".svg": [genFileSuffix]
       };
 }


### PR DESCRIPTION
This PR only includes the SVG image format support for the assets builder.